### PR TITLE
feat(claude_code): track Fast mode usage with 6x pricing

### DIFF
--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -35,17 +36,17 @@ pub struct PricingTable {
     prices: HashMap<String, ModelPricing>,
 }
 
-/// Fallback multipliers for Anthropic Fast mode when LiteLLM lacks a `-fast`
-/// pricing entry. Direct LiteLLM match always wins; this only kicks in for
-/// `<base>-fast` lookups when the base model is priced and the suffix is not.
-/// Source: Anthropic Claude Code fast-mode pricing ($30/$150 vs $5/$25 = 6x).
-const FAST_MULTIPLIER: &[(&str, f64)] = &[
-    ("claude-opus-4-6", 6.0),
-    ("claude-opus-4-7", 6.0),
-];
-
+/// Walk every provider's fast-multiplier table to resolve `<base>` → multiplier.
+/// Returns the first match. Compile-time `const` slices, so iteration is
+/// O(total provider rows) with zero runtime allocation.
 fn fast_multiplier(base: &str) -> Option<f64> {
-    FAST_MULTIPLIER.iter().find_map(|(k, v)| (*k == base).then_some(*v))
+    [
+        crate::providers::claude_code::FAST_MULTIPLIER,
+        crate::providers::codex::FAST_MULTIPLIER,
+    ]
+    .iter()
+    .flat_map(|table| table.iter())
+    .find_map(|(k, v)| (*k == base).then_some(*v))
 }
 
 impl PricingTable {
@@ -60,25 +61,25 @@ impl PricingTable {
     /// Look up effective pricing for a model name.
     ///
     /// Resolution order:
-    /// 1. Direct exact match in LiteLLM data (takes precedence if/when
-    ///    LiteLLM publishes `-fast` rows for Claude models).
+    /// 1. Direct exact match in LiteLLM data — zero-copy `Cow::Borrowed`.
+    ///    Takes precedence if/when LiteLLM publishes `-fast` rows.
     /// 2. `<base>-fast` suffix fallback: base model pricing scaled by the
-    ///    hardcoded fast multiplier table.
-    pub fn get(&self, model: &str) -> Option<ModelPricing> {
+    ///    per-provider multiplier table — `Cow::Owned` (single allocation).
+    pub fn get(&self, model: &str) -> Option<Cow<'_, ModelPricing>> {
         if let Some(p) = self.prices.get(model) {
-            return Some(p.clone());
+            return Some(Cow::Borrowed(p));
         }
         let base = model.strip_suffix("-fast")?;
         let mul = fast_multiplier(base)?;
         let base_p = self.prices.get(base)?;
-        Some(ModelPricing {
+        Some(Cow::Owned(ModelPricing {
             input_cost_per_token: base_p.input_cost_per_token * mul,
             output_cost_per_token: base_p.output_cost_per_token * mul,
             cache_creation_input_token_cost:
                 base_p.cache_creation_input_token_cost.map(|c| c * mul),
             cache_read_input_token_cost:
                 base_p.cache_read_input_token_cost.map(|c| c * mul),
-        })
+        }))
     }
 
     /// Calculate cost for a ModelUsageSummary.
@@ -501,6 +502,45 @@ mod tests {
             (p.cache_read_input_token_cost.unwrap() - 0.0000005 * 6.0).abs()
                 < 1e-12
         );
+    }
+
+    #[test]
+    fn test_direct_match_is_borrowed() {
+        // Hot-path guard: direct LiteLLM matches must not allocate.
+        let mut prices = HashMap::new();
+        prices.insert("claude-opus-4-7".to_string(), ModelPricing {
+            input_cost_per_token: 0.000005,
+            output_cost_per_token: 0.000025,
+            cache_creation_input_token_cost: None,
+            cache_read_input_token_cost: None,
+        });
+        let table = PricingTable::new(prices);
+        let cow = table.get("claude-opus-4-7").unwrap();
+        assert!(matches!(cow, std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn test_fast_fallback_is_owned() {
+        let mut prices = HashMap::new();
+        prices.insert("claude-opus-4-7".to_string(), ModelPricing {
+            input_cost_per_token: 0.000005,
+            output_cost_per_token: 0.000025,
+            cache_creation_input_token_cost: None,
+            cache_read_input_token_cost: None,
+        });
+        let table = PricingTable::new(prices);
+        let cow = table.get("claude-opus-4-7-fast").unwrap();
+        assert!(matches!(cow, std::borrow::Cow::Owned(_)));
+    }
+
+    #[test]
+    fn test_empty_provider_table_safe() {
+        // Codex's FAST_MULTIPLIER is an empty placeholder; the resolver
+        // must still find Claude entries from the other provider's table.
+        assert_eq!(fast_multiplier("claude-opus-4-7"), Some(6.0));
+        // And an unknown base must yield None without panicking on the
+        // empty Codex slice.
+        assert_eq!(fast_multiplier("gpt-5.5"), None);
     }
 
     #[test]

--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -35,6 +35,19 @@ pub struct PricingTable {
     prices: HashMap<String, ModelPricing>,
 }
 
+/// Fallback multipliers for Anthropic Fast mode when LiteLLM lacks a `-fast`
+/// pricing entry. Direct LiteLLM match always wins; this only kicks in for
+/// `<base>-fast` lookups when the base model is priced and the suffix is not.
+/// Source: Anthropic Claude Code fast-mode pricing ($30/$150 vs $5/$25 = 6x).
+const FAST_MULTIPLIER: &[(&str, f64)] = &[
+    ("claude-opus-4-6", 6.0),
+    ("claude-opus-4-7", 6.0),
+];
+
+fn fast_multiplier(base: &str) -> Option<f64> {
+    FAST_MULTIPLIER.iter().find_map(|(k, v)| (*k == base).then_some(*v))
+}
+
 impl PricingTable {
     pub fn new(prices: HashMap<String, ModelPricing>) -> Self {
         PricingTable { prices }
@@ -44,9 +57,28 @@ impl PricingTable {
         self.prices.is_empty()
     }
 
-    /// Look up pricing for a model name (exact match only).
-    pub fn get(&self, model: &str) -> Option<&ModelPricing> {
-        self.prices.get(model)
+    /// Look up effective pricing for a model name.
+    ///
+    /// Resolution order:
+    /// 1. Direct exact match in LiteLLM data (takes precedence if/when
+    ///    LiteLLM publishes `-fast` rows for Claude models).
+    /// 2. `<base>-fast` suffix fallback: base model pricing scaled by the
+    ///    hardcoded fast multiplier table.
+    pub fn get(&self, model: &str) -> Option<ModelPricing> {
+        if let Some(p) = self.prices.get(model) {
+            return Some(p.clone());
+        }
+        let base = model.strip_suffix("-fast")?;
+        let mul = fast_multiplier(base)?;
+        let base_p = self.prices.get(base)?;
+        Some(ModelPricing {
+            input_cost_per_token: base_p.input_cost_per_token * mul,
+            output_cost_per_token: base_p.output_cost_per_token * mul,
+            cache_creation_input_token_cost:
+                base_p.cache_creation_input_token_cost.map(|c| c * mul),
+            cache_read_input_token_cost:
+                base_p.cache_read_input_token_cost.map(|c| c * mul),
+        })
     }
 
     /// Calculate cost for a ModelUsageSummary.
@@ -420,6 +452,70 @@ mod tests {
         };
         let cost = table.event_cost(&event).unwrap();
         assert!((cost - 0.0105).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_fast_suffix_direct_match_wins() {
+        // If LiteLLM ever ships a "-fast" row directly, it must take precedence
+        // over the multiplier fallback.
+        let mut prices = HashMap::new();
+        prices.insert("claude-opus-4-7".to_string(), ModelPricing {
+            input_cost_per_token: 0.000005,
+            output_cost_per_token: 0.000025,
+            cache_creation_input_token_cost: None,
+            cache_read_input_token_cost: None,
+        });
+        prices.insert("claude-opus-4-7-fast".to_string(), ModelPricing {
+            // Pretend LiteLLM ships a hand-tuned (not 6x) value — must not be
+            // overwritten by the fallback table.
+            input_cost_per_token: 0.0000777,
+            output_cost_per_token: 0.0001111,
+            cache_creation_input_token_cost: None,
+            cache_read_input_token_cost: None,
+        });
+        let table = PricingTable::new(prices);
+        let p = table.get("claude-opus-4-7-fast").unwrap();
+        assert!((p.input_cost_per_token - 0.0000777).abs() < 1e-12);
+        assert!((p.output_cost_per_token - 0.0001111).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_fast_suffix_multiplier_fallback() {
+        // Base model priced, "-fast" row missing → apply 6x multiplier.
+        let mut prices = HashMap::new();
+        prices.insert("claude-opus-4-7".to_string(), ModelPricing {
+            input_cost_per_token: 0.000005,
+            output_cost_per_token: 0.000025,
+            cache_creation_input_token_cost: Some(0.00000625),
+            cache_read_input_token_cost: Some(0.0000005),
+        });
+        let table = PricingTable::new(prices);
+        let p = table.get("claude-opus-4-7-fast").unwrap();
+        assert!((p.input_cost_per_token - 0.000005 * 6.0).abs() < 1e-12);
+        assert!((p.output_cost_per_token - 0.000025 * 6.0).abs() < 1e-12);
+        assert!(
+            (p.cache_creation_input_token_cost.unwrap() - 0.00000625 * 6.0).abs()
+                < 1e-12
+        );
+        assert!(
+            (p.cache_read_input_token_cost.unwrap() - 0.0000005 * 6.0).abs()
+                < 1e-12
+        );
+    }
+
+    #[test]
+    fn test_fast_suffix_unknown_base_returns_none() {
+        // "-fast" suffix but base model not in multiplier table → no fallback.
+        let mut prices = HashMap::new();
+        prices.insert("claude-sonnet-4-5".to_string(), ModelPricing {
+            input_cost_per_token: 0.000003,
+            output_cost_per_token: 0.000015,
+            cache_creation_input_token_cost: None,
+            cache_read_input_token_cost: None,
+        });
+        let table = PricingTable::new(prices);
+        // Sonnet isn't in FAST_MULTIPLIER → no fallback, even though base exists.
+        assert!(table.get("claude-sonnet-4-5-fast").is_none());
     }
 
     #[test]

--- a/src/providers/claude_code/mod.rs
+++ b/src/providers/claude_code/mod.rs
@@ -2,6 +2,15 @@ pub mod parser;
 
 pub use parser::ClaudeCodeParser;
 
+/// Fast-mode pricing multipliers for Anthropic models.
+/// Applied by `pricing::PricingTable::get` when a `<base>-fast` lookup
+/// misses the LiteLLM table (direct `-fast` rows always win).
+/// Source: Anthropic Claude Code fast-mode pricing ($30/$150 vs $5/$25 = 6x).
+pub const FAST_MULTIPLIER: &[(&str, f64)] = &[
+    ("claude-opus-4-6", 6.0),
+    ("claude-opus-4-7", 6.0),
+];
+
 use crate::common::types::{LogParser, LogParserWithTs, SessionGroup};
 use crate::providers::{
     ColdStartParsed, FileParser, Provider,

--- a/src/providers/claude_code/parser.rs
+++ b/src/providers/claude_code/parser.rs
@@ -17,11 +17,12 @@ struct JsonlLine<'a> {
 struct MessagePartial<'a> {
     id: Option<&'a str>,
     model: Option<&'a str>,
-    usage: Option<UsageData>,
+    #[serde(borrow)]
+    usage: Option<UsageData<'a>>,
 }
 
 #[derive(Deserialize)]
-struct UsageData {
+struct UsageData<'a> {
     #[serde(default)]
     input_tokens: u64,
     #[serde(default)]
@@ -30,13 +31,15 @@ struct UsageData {
     cache_read_input_tokens: u64,
     #[serde(default)]
     output_tokens: u64,
+    #[serde(default, borrow)]
+    speed: Option<&'a str>,
 }
 
 struct ParsedLine<'a> {
     message_id: &'a str,
-    model: &'a str,
+    model: String,
     timestamp: &'a str,
-    usage: UsageData,
+    usage: UsageData<'a>,
 }
 
 pub struct ClaudeCodeParser;
@@ -69,12 +72,19 @@ impl ClaudeCodeParser {
 
         let msg = parsed.message?;
         let usage = msg.usage?;
-        let model = msg.model.unwrap_or("unknown");
+        let base_model = msg.model.unwrap_or("unknown");
 
         // Skip synthetic events (internally generated, no real API call)
-        if model == "<synthetic>" {
+        if base_model == "<synthetic>" {
             return None;
         }
+
+        // Anthropic Fast mode: suffix model with "-fast" so pricing/breakdowns separate.
+        let model = if matches!(usage.speed, Some("fast")) {
+            format!("{}-fast", base_model)
+        } else {
+            base_model.to_string()
+        };
 
         Some(ParsedLine {
             message_id: msg.id.unwrap_or(""),
@@ -92,7 +102,7 @@ impl ClaudeCodeParser {
         Some(UsageEventWithTs {
             event_key,
             source_file: source_file.to_string(),
-            model: parsed.model.to_string(),
+            model: parsed.model,
             input_tokens: parsed.usage.input_tokens,
             cache_creation_input_tokens: parsed.usage.cache_creation_input_tokens,
             cache_read_input_tokens: parsed.usage.cache_read_input_tokens,
@@ -112,7 +122,7 @@ impl ClaudeCodeParser {
 
         Some(crate::providers::ColdStartParsed {
             event_key,
-            model: parsed.model.to_string(),
+            model: parsed.model,
             ts_ms,
             tokens: crate::common::types::TokenFields {
                 input_tokens: parsed.usage.input_tokens,
@@ -134,7 +144,7 @@ impl LogParser for ClaudeCodeParser {
         Some(UsageEvent {
             event_key,
             source_file: source_file.to_string(),
-            model: parsed.model.to_string(),
+            model: parsed.model,
             input_tokens: parsed.usage.input_tokens,
             cache_creation_input_tokens: parsed.usage.cache_creation_input_tokens,
             cache_read_input_tokens: parsed.usage.cache_read_input_tokens,
@@ -263,6 +273,30 @@ mod tests {
     fn test_skip_invalid_json() {
         let parser = ClaudeCodeParser;
         assert!(parser.parse_line("not json", "/test.jsonl").is_none());
+    }
+
+    #[test]
+    fn test_speed_fast_suffixes_model() {
+        let line = r#"{"type":"assistant","message":{"id":"msg_1","model":"claude-opus-4-7","usage":{"input_tokens":1,"output_tokens":2,"speed":"fast"}},"timestamp":"2026-03-08T12:00:00Z"}"#;
+        let parser = ClaudeCodeParser;
+        let event = parser.parse_line(line, "/test.jsonl").unwrap();
+        assert_eq!(event.model, "claude-opus-4-7-fast");
+    }
+
+    #[test]
+    fn test_speed_standard_no_suffix() {
+        let line = r#"{"type":"assistant","message":{"id":"msg_1","model":"claude-opus-4-7","usage":{"input_tokens":1,"output_tokens":2,"speed":"standard"}},"timestamp":"2026-03-08T12:00:00Z"}"#;
+        let parser = ClaudeCodeParser;
+        let event = parser.parse_line(line, "/test.jsonl").unwrap();
+        assert_eq!(event.model, "claude-opus-4-7");
+    }
+
+    #[test]
+    fn test_speed_absent_no_suffix() {
+        let line = r#"{"type":"assistant","message":{"id":"msg_1","model":"claude-opus-4-7","usage":{"input_tokens":1,"output_tokens":2}},"timestamp":"2026-03-08T12:00:00Z"}"#;
+        let parser = ClaudeCodeParser;
+        let event = parser.parse_line(line, "/test.jsonl").unwrap();
+        assert_eq!(event.model, "claude-opus-4-7");
     }
 
     #[test]

--- a/src/providers/codex/mod.rs
+++ b/src/providers/codex/mod.rs
@@ -2,6 +2,15 @@ pub mod parser;
 
 pub use parser::CodexParser;
 
+/// Fast-mode pricing multipliers for Codex models.
+/// Empty placeholder: Codex JSONL carries no service_tier marker and the
+/// OpenAI API response does not echo it back, so per-event Fast detection
+/// is impossible. Populate this list only if Codex CLI starts recording
+/// the tier inside its session JSONL.
+/// Reference (ccusage's table, kept here for future activation):
+///   gpt-5.5 -> 2.5x, gpt-5.4 -> 2.0x, gpt-5.3-codex -> 2.0x
+pub const FAST_MULTIPLIER: &[(&str, f64)] = &[];
+
 use std::path::PathBuf;
 
 use crate::common::types::{LogParser, LogParserWithTs, SessionGroup};


### PR DESCRIPTION
## Summary

- Anthropic Claude Code의 `/fast` 모드를 별도 모델로 추적하고 6x 가격을 적용합니다.
- `usage.speed = \"fast\"`가 들어 있는 라인은 model name에 `-fast` 접미사가 붙어 dict/breakdown/cost 모두 분리됩니다.
- LiteLLM이 `-fast` 모델 가격을 등록하지 않은 동안의 fallback으로 \`base × 6.0\` multiplier를 적용 (출처: Anthropic Claude Code fast-mode pricing \$30/\$150 vs \$5/\$25).

## Changes

**Commit 1 — `feat(claude_code): track Fast mode usage and apply 6x pricing`**
- `src/providers/claude_code/parser.rs`: `UsageData<'a>`에 `speed: Option<&'a str>` 추가, `usage.speed == \"fast\"` 감지 시 model에 \`-fast\` 접미사
- `src/pricing.rs`: \`PricingTable::get\`에 \`<base>-fast\` fallback (multiplier × base 가격)
- 새 테스트 6개

**Commit 2 — `refactor(pricing): scope fast multipliers per provider, return Cow`**
- Multiplier 테이블을 `providers/claude_code/mod.rs`로 이동, `providers/codex/mod.rs`에 빈 placeholder
- \`PricingTable::get\` 반환을 \`Option<Cow<'_, ModelPricing>>\`로 — 직접 매치 경로 zero-copy (trace + cost hot path)
- 새 테스트 3개

## 의도적으로 빠진 항목 — Codex Fast

조사 결과 Codex JSONL/OpenAI API 응답 어디에도 service_tier 마커가 없어 mixed usage 자동 감지 불가. ccusage의 config.toml sweep 방식은 정확도 낮아 toki ethos와 충돌. Codex CLI가 JSONL에 마커를 추가하는 시점에 reactive 대응 — \`providers/codex/mod.rs\`에 빈 placeholder만 마련해두어 그때 한 줄 추가로 활성화 가능.

## DB 호환성

\`SCHEMA_VERSION\` 무변경 — 자동 reset 없음. 새 model 이름이 dict에 새 ID로 추가될 뿐인 additive 변경.

## Test plan

- [x] \`cargo test --lib\` — 183 passed (이전 174 + 새 9)
- [x] \`cargo build --release\` 통과
- [x] \`cargo clippy --lib --no-deps\` — 신규 warning 0
- [x] 기존 standard 데이터 회귀 없음 (\`test_speed_standard_no_suffix\`, \`test_speed_absent_no_suffix\`)
- [x] Phase A+B 통합 로컬 실행 검증 — daemon 정상 동작, report 출력 동일 (본인 데이터 fast 0건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)